### PR TITLE
feat: Adding public agent specific openapi endpoints

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,8 @@ The Agent Workflow Server, and the underlying Agent, could be optionally authent
 
 Once the Agent Workflow Server is running, interactive API docs are available under `/docs` endpoint, redoc documentation under `/redoc` endpoint
 
+For detailed API documentation specific to an agent, access the interactive documentation at `/agent/{agent_id}/docs`, where `{agent_id}` is the identifier of your deployed agent.
+
 ## Contributing
 
 ### ACP API Contribution

--- a/src/agent_workflow_server/agents/load.py
+++ b/src/agent_workflow_server/agents/load.py
@@ -122,7 +122,7 @@ Check that the module name and export symbol in 'AGENTS_REF' env variable are co
         raise ImportError("Failed to load agent manifest")
 
     try:
-        schema = generate_agent_oapi(manifest)
+        schema = generate_agent_oapi(manifest, name)
     except Exception as e:
         raise ImportError("Failed to generate OAPI schema:", e)
 

--- a/src/agent_workflow_server/apis/agents.py
+++ b/src/agent_workflow_server/apis/agents.py
@@ -132,6 +132,7 @@ async def get_agent_openapi(
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 
+
 @public_router.get(
     "/agents/{agent_id}/docs",
     responses={

--- a/src/agent_workflow_server/apis/agents.py
+++ b/src/agent_workflow_server/apis/agents.py
@@ -13,6 +13,7 @@ from fastapi import (  # noqa: F401
     Request,
     Response,
 )
+from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import HTMLResponse
 from pydantic import Field, StrictStr
 from typing_extensions import Annotated
@@ -131,7 +132,6 @@ async def get_agent_openapi(
     except Exception as e:
         raise HTTPException(status_code=404, detail=str(e))
 
-
 @public_router.get(
     "/agents/{agent_id}/docs",
     responses={
@@ -142,9 +142,7 @@ async def get_agent_openapi(
         404: {"model": str, "description": "Not Found"},
     },
     tags=["Agents"],
-    summary="Get Agent specifc Swagger UI",
-    response_model_by_alias=True,
-    dependencies=[],
+    summary="Get Agent specific Swagger UI",
 )
 async def get_agent_docs(
     request: Request,
@@ -154,30 +152,7 @@ async def get_agent_docs(
     ),
 ) -> HTMLResponse:
     """Get the Swagger UI documentation for an agent by ID."""
-    html = f"""
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Agent OpenAPI Documentation</title>
-        <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
-        <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    </head>
-    <body>
-        <div id="swagger-ui"></div>
-        <script>
-            window.onload = function() {{
-                SwaggerUIBundle({{
-                    url: "{request.url_for("get_agent_openapi", agent_id=agent_id)}",
-                    dom_id: '#swagger-ui',
-                    deepLinking: true,
-                    presets: [
-                        SwaggerUIBundle.presets.apis,
-                        SwaggerUIBundle.SwaggerUIStandalonePreset
-                    ],
-                }})
-            }}
-        </script>
-    </body>
-    </html>
-    """
-    return HTMLResponse(content=html)
+    return get_swagger_ui_html(
+        openapi_url=request.url_for("get_agent_openapi", agent_id=agent_id),
+        title="Agent API Documentation",
+    )

--- a/src/agent_workflow_server/apis/authentication.py
+++ b/src/agent_workflow_server/apis/authentication.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Security
+from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
 from fastapi.security.api_key import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED
@@ -50,7 +51,29 @@ def setup_api_key_auth(app: FastAPI) -> None:
         }
         openapi_schema["security"] = [{"ApiKeyAuth": []}]
 
+        for path in openapi_schema["paths"].values():
+            for operation in path.values():
+                operation["security"] = [{"ApiKeyAuth": []}]
+
         app.openapi_schema = openapi_schema
         return app.openapi_schema
 
     app.openapi = custom_openapi
+
+    # Override the default swagger UI to include persistent auth
+    def custom_swagger_ui_html():
+        return get_swagger_ui_html(
+            openapi_url=app.openapi_url,
+            title=app.title,
+            swagger_js_url="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
+            swagger_css_url="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
+            swagger_favicon_url="/static/favicon.png",
+            init_oauth={},
+            swagger_ui_parameters={
+                "persistAuthorization": True,
+                "displayRequestDuration": True,
+                "tryItOutEnabled": True,
+            },
+        )
+
+    app.swagger_ui_html = custom_swagger_ui_html

--- a/src/agent_workflow_server/apis/authentication.py
+++ b/src/agent_workflow_server/apis/authentication.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Security
-from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.openapi.utils import get_openapi
 from fastapi.security.api_key import APIKeyHeader
 from starlette.status import HTTP_401_UNAUTHORIZED
@@ -50,24 +49,6 @@ def setup_api_key_auth(app: FastAPI) -> None:
         return app.openapi_schema
 
     app.openapi = custom_openapi
-
-    # Override the default swagger UI to include persistent auth
-    def custom_swagger_ui_html():
-        return get_swagger_ui_html(
-            openapi_url=app.openapi_url,
-            title=app.title,
-            swagger_js_url="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js",
-            swagger_css_url="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css",
-            swagger_favicon_url="/static/favicon.png",
-            init_oauth={},
-            swagger_ui_parameters={
-                "persistAuthorization": True,
-                "displayRequestDuration": True,
-                "tryItOutEnabled": True,
-            },
-        )
-
-    app.swagger_ui_html = custom_swagger_ui_html
 
 
 def add_authentication_to_spec(spec_dict: dict) -> dict:

--- a/src/agent_workflow_server/main.py
+++ b/src/agent_workflow_server/main.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI
 
 from agent_workflow_server.agents.load import load_agents
+from agent_workflow_server.apis.agents import public_router as PublicAgentsApiRouter
 from agent_workflow_server.apis.agents import router as AgentsApiRouter
 from agent_workflow_server.apis.authentication import (
     authentication_with_api_key,
@@ -41,6 +42,9 @@ setup_api_key_auth(app)
 app.include_router(
     router=AgentsApiRouter,
     dependencies=[Depends(authentication_with_api_key)],
+)
+app.include_router(
+    router=PublicAgentsApiRouter,
 )
 app.include_router(
     router=StatelessRunsApiRouter,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import uuid
+
 import pytest
 
 from agent_workflow_server.agents.oas_generator import (
@@ -40,7 +42,7 @@ def basic_descriptor():
 
 def test_generate_basic_spec(basic_descriptor):
     """Test generating a basic spec with minimal capabilities"""
-    result = generate_agent_oapi(basic_descriptor)
+    result = generate_agent_oapi(basic_descriptor, str(uuid.uuid4()))
 
     # Verify basic structure
     assert "openapi" in result

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -13,9 +13,13 @@ from agent_workflow_server.generated.models.agent_acp_descriptor import (
     AgentACPDescriptor,
 )
 from agent_workflow_server.generated.models.agent_acp_spec import AgentACPSpec
+from agent_workflow_server.generated.models.agent_acp_spec_interrupts_inner import (
+    AgentACPSpecInterruptsInner,
+)
 from agent_workflow_server.generated.models.agent_capabilities import AgentCapabilities
 from agent_workflow_server.generated.models.agent_metadata import AgentMetadata
 from agent_workflow_server.generated.models.agent_ref import AgentRef
+from agent_workflow_server.generated.models.streaming_modes import StreamingModes
 
 
 @pytest.fixture
@@ -42,19 +46,27 @@ def basic_descriptor():
 
 def test_generate_basic_spec(basic_descriptor):
     """Test generating a basic spec with minimal capabilities"""
-    result = generate_agent_oapi(basic_descriptor, str(uuid.uuid4()))
+    agent_id = str(uuid.uuid4())
+    result = generate_agent_oapi(basic_descriptor, agent_id)
 
     # Verify basic structure
     assert "openapi" in result
     assert "info" in result
+    assert (
+        result["info"]["title"]
+        == f"ACP Spec for {basic_descriptor.metadata.ref.name}:{basic_descriptor.metadata.ref.version}"
+    )
     assert "paths" in result
     assert "components" in result
 
     # Verify schemas
     schemas = result["components"]["schemas"]
     assert "InputSchema" in schemas
+    assert schemas["InputSchema"]["properties"]["test"]["type"] == "string"
     assert "OutputSchema" in schemas
+    assert schemas["OutputSchema"]["properties"]["result"]["type"] == "string"
     assert "ConfigSchema" in schemas
+    assert schemas["ConfigSchema"]["properties"]["mode"]["type"] == "string"
 
     # Verify no thread paths exist
     assert "/threads" not in result["paths"]
@@ -62,3 +74,148 @@ def test_generate_basic_spec(basic_descriptor):
 
     # Verify no streaming endpoints
     assert "/runs/{run_id}/stream" not in result["paths"]
+
+    # Verify no webhook/callback properties
+    assert "webhook" not in result["components"]["schemas"]["RunCreate"]["properties"]
+
+    # Verify security schemes
+    assert "securitySchemes" in result["components"]
+    assert "ApiKeyAuth" in result["components"]["securitySchemes"]
+    assert result["components"]["securitySchemes"]["ApiKeyAuth"]["type"] == "apiKey"
+    assert result["components"]["securitySchemes"]["ApiKeyAuth"]["in"] == "header"
+
+    # Verify default agent_id is set
+    for path in result["paths"].values():
+        for operation in path.values():
+            if isinstance(operation, dict) and "parameters" in operation:
+                for param in operation["parameters"]:
+                    if param.get("name") == "agent_id":
+                        assert param["schema"]["default"] == agent_id
+
+
+# Add a new test for full capabilities
+@pytest.fixture
+def full_descriptor():
+    """Create a descriptor with all capabilities enabled"""
+    return AgentACPDescriptor(
+        metadata=AgentMetadata(
+            ref=AgentRef(name="full-agent", version="1.0.0", url=None),
+            description="Full capability agent",
+        ),
+        specs=AgentACPSpec(
+            capabilities=AgentCapabilities(
+                threads=True,
+                interrupts=True,
+                callbacks=True,
+                streaming=StreamingModes(native=True, custom=False),
+            ),
+            input={"type": "object", "properties": {"test": {"type": "string"}}},
+            output={"type": "object", "properties": {"result": {"type": "string"}}},
+            config={"type": "object", "properties": {"mode": {"type": "string"}}},
+            thread_state={
+                "type": "object",
+                "properties": {"status": {"type": "string"}},
+            },
+            interrupts=[
+                AgentACPSpecInterruptsInner(
+                    interrupt_type="stop",
+                    interrupt_payload={
+                        "type": "object",
+                        "properties": {"reason": {"type": "string"}},
+                    },
+                    resume_payload={"type": "object", "properties": {}},
+                )
+            ],
+            custom_streaming_update=None,
+        ),
+    )
+
+
+def test_generate_full_spec(full_descriptor):
+    """Test generating a spec with all capabilities enabled"""
+    agent_id = str(uuid.uuid4())
+    result = generate_agent_oapi(full_descriptor, agent_id)
+
+    # Verify thread capabilities
+    assert "/threads" in result["paths"]
+    assert "/threads/search" in result["paths"]
+    assert "ThreadState" in result["components"]["schemas"]
+    assert (
+        result["components"]["schemas"]["ThreadState"]["properties"]["status"]["type"]
+        == "string"
+    )
+
+    # Verify streaming capabilities in more detail
+    assert "/runs/{run_id}/stream" in result["paths"]
+    run_create_schema = result["components"]["schemas"]["RunCreate"]
+    assert "properties" in run_create_schema
+
+    # Verify stream_mode property structure
+    assert "stream_mode" in run_create_schema["properties"]
+    stream_mode_prop = run_create_schema["properties"]["stream_mode"]
+
+    # Verify the anyOf structure
+    assert "anyOf" in stream_mode_prop, f"Expected 'anyOf' in {stream_mode_prop}"
+    assert isinstance(stream_mode_prop["anyOf"], list)
+    assert len(stream_mode_prop["anyOf"]) == 3  # array, single value, or null
+
+    # Verify array option
+    array_option = stream_mode_prop["anyOf"][0]
+    assert array_option["type"] == "array"
+    assert "items" in array_option
+    assert array_option["items"]["$ref"] == "#/components/schemas/StreamingMode"
+
+    # Verify single value option
+    single_option = stream_mode_prop["anyOf"][1]
+    assert single_option["$ref"] == "#/components/schemas/StreamingMode"
+
+    # Verify null option
+    null_option = stream_mode_prop["anyOf"][2]
+    assert null_option["type"] == "null"
+
+    # Verify metadata
+    assert stream_mode_prop["title"] == "Stream Mode"
+    assert "description" in stream_mode_prop
+    assert stream_mode_prop["default"] is None
+
+    # Verify interrupt capabilities
+    assert "/runs/{run_id}/cancel" in result["paths"], (
+        f"Expected cancel path, got paths: {list(result['paths'].keys())}"
+    )
+
+    # Verify cancel endpoint structure
+    cancel_path = result["paths"]["/runs/{run_id}/cancel"]
+    assert "post" in cancel_path
+
+    # Verify cancel endpoint details
+    cancel_post = cancel_path["post"]
+    assert "operationId" in cancel_post
+    assert "parameters" in cancel_post
+    assert any(param["name"] == "run_id" for param in cancel_post["parameters"])
+
+    # Verify security is applied
+    assert "security" in cancel_post
+    assert [{"ApiKeyAuth": []}] == cancel_post["security"]
+
+    # Verify responses
+    assert "responses" in cancel_post
+    assert "204" in cancel_post["responses"], (
+        f"Expected 204 response, got: {list(cancel_post['responses'].keys())}"
+    )
+
+    # 204 No Content shouldn't have a response body
+    assert "content" not in cancel_post["responses"]["204"], (
+        "204 responses should not have content"
+    )
+
+    # Verify error responses are present
+    assert "422" in cancel_post["responses"], "Validation error response missing"
+    assert "content" in cancel_post["responses"]["422"]
+    assert "application/json" in cancel_post["responses"]["422"]["content"]
+    assert (
+        cancel_post["responses"]["422"]["content"]["application/json"]["schema"]["$ref"]
+        == "#/components/schemas/ErrorResponse"
+    )
+
+    # Verify callback capabilities
+    assert "webhook" in result["components"]["schemas"]["RunCreate"]["properties"]


### PR DESCRIPTION
# Description

- Adding an agents/{id}/docs endpoint to display swagger UI for agent specific oas. Provide default value for agent id.
- Adding a fix for the general swagger UI.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
