### PR TITLE
fix: improve error handling for OpenAPI spec file loading

### DIFF
--- a/src/agent_workflow_server/agents/oas_generator.py
+++ b/src/agent_workflow_server/agents/oas_generator.py
@@ -103,12 +103,12 @@ def _add_default_agent_id(spec_dict, agent_id: str):
 
 def generate_agent_oapi(descriptor: AgentACPDescriptor, agent_id: str):
     spec_path = os.getenv("ACP_SPEC_PATH", "acp-spec/openapi.json")
-    
+
     # Check if file exists
     # TODO: Remove this check when the spec is guaranteed to be present
     if not os.path.exists(spec_path):
         return "Unable to find the base OpenAPI spec file."
-        
+
     try:
         spec_dict, base_uri = read_from_filename(spec_path)
     except FileNotFoundError:

--- a/src/agent_workflow_server/agents/oas_generator.py
+++ b/src/agent_workflow_server/agents/oas_generator.py
@@ -102,9 +102,17 @@ def _add_default_agent_id(spec_dict, agent_id: str):
 
 
 def generate_agent_oapi(descriptor: AgentACPDescriptor, agent_id: str):
-    spec_dict, base_uri = read_from_filename(
-        os.getenv("ACP_SPEC_PATH", "acp-spec/openapi.json")
-    )
+    spec_path = os.getenv("ACP_SPEC_PATH", "acp-spec/openapi.json")
+    
+    # Check if file exists
+    # TODO: Remove this check when the spec is guaranteed to be present
+    if not os.path.exists(spec_path):
+        return "Unable to find the base OpenAPI spec file."
+        
+    try:
+        spec_dict, base_uri = read_from_filename(spec_path)
+    except FileNotFoundError:
+        return None
 
     # If no exception is raised by validate(), the spec is valid.
     validate(spec_dict)


### PR DESCRIPTION
# Description

We either enforce a base openapi.json location or make sure that the wfs not stops when the json not exist. 
This is a solution to use until that.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
