### PR TITLE
fix: change search_agents function name that collide with the one on the api

### DIFF
--- a/src/agent_workflow_server/agents/load.py
+++ b/src/agent_workflow_server/agents/load.py
@@ -172,7 +172,7 @@ def get_agent_from_agent_info(agent_id: str, agent_info: AgentInfo) -> Agent:
     return Agent(agent_id=agent_id, metadata=agent_info.manifest.metadata)
 
 
-def search_agents(search_request: AgentSearchRequest) -> List[Agent]:
+def search_for_agents(search_request: AgentSearchRequest) -> List[Agent]:
     if not search_request.name and not search_request.version:
         raise ValueError("At least one of 'name' or 'version' must be provided")
 

--- a/src/agent_workflow_server/apis/agents.py
+++ b/src/agent_workflow_server/apis/agents.py
@@ -22,6 +22,7 @@ from agent_workflow_server.agents.load import (
     get_agent,
     get_agent_info,
     get_agent_openapi_schema,
+    search_for_agents,
 )
 from agent_workflow_server.generated.models.agent import Agent
 from agent_workflow_server.generated.models.agent_acp_descriptor import (
@@ -100,7 +101,7 @@ async def search_agents(
     """Returns a list of agents matching the criteria provided in the request.  This endpoint also functions as the endpoint to list all agents."""
 
     try:
-        agents = search_agents(agent_search_request)
+        agents = search_for_agents(agent_search_request)
         return agents
     except Exception as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/src/agent_workflow_server/apis/stateless_runs.py
+++ b/src/agent_workflow_server/apis/stateless_runs.py
@@ -261,7 +261,7 @@ async def search_stateless_runs(
     run_search_request: RunSearchRequest = Body(None, description=""),
 ) -> List[RunStateless]:
     """Search for stateless run.  This endpoint also functions as the endpoint to list all stateless Runs."""
-    return Runs.search(run_search_request)
+    return Runs.search_for_runs(run_search_request)
 
 
 @router.get(

--- a/src/agent_workflow_server/services/runs.py
+++ b/src/agent_workflow_server/services/runs.py
@@ -149,7 +149,7 @@ class Runs:
         return [_to_api_model(run) for run in db_runs]
 
     @staticmethod
-    def search(search_request: RunSearchRequest) -> List[ApiRun]:
+    def search_for_runs(search_request: RunSearchRequest) -> List[ApiRun]:
         filters = {}
         if search_request.agent_id:
             filters["agent_id"] = search_request.agent_id

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -9,7 +9,7 @@ from agent_workflow_server.agents.load import (
     get_agent,
     get_agent_info,
     load_agents,
-    search_agents,
+    search_for_agents,
 )
 from agent_workflow_server.generated.models.agent_search_request import (
     AgentSearchRequest,
@@ -92,7 +92,7 @@ def test_search_agents(
     assert len(AGENTS) == 1
 
     try:
-        agents = search_agents(AgentSearchRequest(name=name, version=version))
+        agents = search_for_agents(AgentSearchRequest(name=name, version=version))
         assert not exception
         assert len(agents) == expected
     except Exception:

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -186,7 +186,7 @@ async def test_search_runs(
         )
 
         try:
-            runs = Runs.search(
+            runs = Runs.search_for_runs(
                 RunSearchRequest(
                     agent_id=agent_id, status=status, offset=offset, limit=limit
                 )


### PR DESCRIPTION
# Description

in load.py, we defined the function:
```
def search_agents(search_request: AgentSearchRequest) -> List[Agent]:
    ...
```
But openapi-generator-cli generate also a function:
```
async def search_agents(
    agent_search_request: AgentSearchRequest = Body(None, description=""),
) -> List[Agent]:
    ....
```
This is a proposal to change the name of the function in load.py to not collide the async function from openapi_generator.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
