### PR TITLE
fix: checkout submodule on repo checkout

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yaml
+++ b/.github/workflows/reusable-docker-build-push.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
+          submodules: 'true'
           fetch-depth: 0
 
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
# Description

Checkout submodule on repo checkout, since workflow-srv needs the acp-spec/openapi.json in the image.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
