### PR TITLE
Add default agent-id support for api with default agent-id

### DIFF
--- a/src/agent_workflow_server/agents/load.py
+++ b/src/agent_workflow_server/agents/load.py
@@ -183,6 +183,13 @@ def get_agent(agent_id: str) -> Agent:
     return Agent(agent_id=agent_id, metadata=AGENTS[agent_id].manifest.metadata)
 
 
+def get_default_agent() -> Agent:
+    if len(AGENTS) == 0:
+        raise ValueError("No agents available")
+    agent_id = next(iter(AGENTS))
+    return Agent(agent_id=agent_id, metadata=AGENTS[agent_id].manifest.metadata)
+
+
 def get_agent_from_agent_info(agent_id: str, agent_info: AgentInfo) -> Agent:
     if agent_id not in AGENTS:
         raise ValueError(f'Agent "{agent_id}" not found')

--- a/src/agent_workflow_server/agents/oas_generator.py
+++ b/src/agent_workflow_server/agents/oas_generator.py
@@ -102,7 +102,7 @@ def _add_default_agent_id(spec_dict, agent_id: str):
         for operation in path_item.values():
             if not isinstance(operation, dict):
                 continue
-            
+
             if "parameters" in operation:
                 for param in operation["parameters"]:
                     if param.get("name") == "agent_id":

--- a/src/agent_workflow_server/apis/stateless_runs.py
+++ b/src/agent_workflow_server/apis/stateless_runs.py
@@ -18,6 +18,7 @@ from fastapi import (
 from pydantic import Field, StrictBool, StrictStr
 from typing_extensions import Annotated
 
+from agent_workflow_server.agents.load import get_default_agent
 from agent_workflow_server.generated.models.run_create_stateless import (
     RunCreateStateless,
 )
@@ -42,6 +43,24 @@ from agent_workflow_server.services.validation import (
 )
 
 router = APIRouter()
+
+
+def _pre_process_RunCreateStateless(
+    run_create_stateless: RunCreateStateless,
+) -> RunCreateStateless:
+    """Pre-process the RunCreateStateless object to set the agent_id if not provided."""
+    if run_create_stateless.agent_id is None:
+        run_create_stateless.agent_id = get_default_agent().agent_id
+    return run_create_stateless
+
+
+def _pre_process_RunSearchRequest(
+    run_search_request: RunSearchRequest,
+) -> RunSearchRequest:
+    """Pre-process the RunSearchRequest object to set the agent_id if not provided."""
+    if run_search_request.agent_id is None:
+        run_search_request.agent_id = get_default_agent().agent_id
+    return run_search_request
 
 
 async def _validate_run_create(
@@ -144,6 +163,7 @@ async def create_and_stream_stateless_run_output(
     run_create_stateless: RunCreateStateless = Body(None, description=""),
 ) -> RunOutputStream:
     """Create a stateless run and join its output stream. See &#39;GET /runs/{run_id}/stream&#39; for details on the return values."""
+    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -164,6 +184,7 @@ async def create_and_wait_for_stateless_run_output(
     run_create_stateless: RunCreateStateless = Body(None, description=""),
 ) -> RunWaitResponseStateless:
     """Create a stateless run and wait for its output. See &#39;GET /runs/{run_id}/wait&#39; for details on the return values."""
+    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     new_run = await Runs.put(run_create_stateless)
     return await _wait_and_return_run_output(new_run.run_id)
 
@@ -185,6 +206,7 @@ async def create_stateless_run(
     run_create_stateless: RunCreateStateless = Body(None, description=""),
 ) -> RunStateless:
     """Create a stateless run, return the run ID immediately. Don&#39;t wait for the final run output."""
+    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     return await Runs.put(run_create_stateless)
 
 
@@ -276,6 +298,7 @@ async def search_stateless_runs(
     run_search_request: RunSearchRequest = Body(None, description=""),
 ) -> List[RunStateless]:
     """Search for stateless run.  This endpoint also functions as the endpoint to list all stateless Runs."""
+    run_search_request = _pre_process_RunSearchRequest(run_search_request)
     return Runs.search_for_runs(run_search_request)
 
 

--- a/src/agent_workflow_server/apis/stateless_runs.py
+++ b/src/agent_workflow_server/apis/stateless_runs.py
@@ -45,20 +45,20 @@ from agent_workflow_server.services.validation import (
 router = APIRouter()
 
 
-def _pre_process_RunCreateStateless(
+async def _validate_run_create_stateless(
     run_create_stateless: RunCreateStateless,
 ) -> RunCreateStateless:
-    """Pre-process the RunCreateStateless object to set the agent_id if not provided."""
     if run_create_stateless.agent_id is None:
+        """Pre-process the RunCreateStateless object to set the agent_id if not provided."""
         run_create_stateless.agent_id = get_default_agent().agent_id
     return run_create_stateless
 
 
-def _pre_process_RunSearchRequest(
+async def _validate_run_search_request(
     run_search_request: RunSearchRequest,
 ) -> RunSearchRequest:
-    """Pre-process the RunSearchRequest object to set the agent_id if not provided."""
     if run_search_request.agent_id is None:
+        """Pre-process the RunSearchRequest object to set the agent_id if not provided."""
         run_search_request.agent_id = get_default_agent().agent_id
     return run_search_request
 
@@ -160,10 +160,11 @@ async def cancel_stateless_run(
     dependencies=[Depends(_validate_run_create)],
 )
 async def create_and_stream_stateless_run_output(
-    run_create_stateless: RunCreateStateless = Body(None, description=""),
+    run_create_stateless: Annotated[
+        RunCreateStateless, Depends(_validate_run_create_stateless)
+    ] = Body(None, description=""),
 ) -> RunOutputStream:
     """Create a stateless run and join its output stream. See &#39;GET /runs/{run_id}/stream&#39; for details on the return values."""
-    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -181,10 +182,11 @@ async def create_and_stream_stateless_run_output(
     dependencies=[Depends(_validate_run_create)],
 )
 async def create_and_wait_for_stateless_run_output(
-    run_create_stateless: RunCreateStateless = Body(None, description=""),
+    run_create_stateless: Annotated[
+        RunCreateStateless, Depends(_validate_run_create_stateless)
+    ] = Body(None, description=""),
 ) -> RunWaitResponseStateless:
     """Create a stateless run and wait for its output. See &#39;GET /runs/{run_id}/wait&#39; for details on the return values."""
-    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     new_run = await Runs.put(run_create_stateless)
     return await _wait_and_return_run_output(new_run.run_id)
 
@@ -203,10 +205,11 @@ async def create_and_wait_for_stateless_run_output(
     dependencies=[Depends(_validate_run_create)],
 )
 async def create_stateless_run(
-    run_create_stateless: RunCreateStateless = Body(None, description=""),
+    run_create_stateless: Annotated[
+        RunCreateStateless, Depends(_validate_run_create_stateless)
+    ] = Body(None, description=""),
 ) -> RunStateless:
     """Create a stateless run, return the run ID immediately. Don&#39;t wait for the final run output."""
-    run_create_stateless = _pre_process_RunCreateStateless(run_create_stateless)
     return await Runs.put(run_create_stateless)
 
 
@@ -295,10 +298,11 @@ async def resume_stateless_run(
     response_model_by_alias=True,
 )
 async def search_stateless_runs(
-    run_search_request: RunSearchRequest = Body(None, description=""),
+    run_search_request: Annotated[
+        RunSearchRequest, Depends(_validate_run_search_request)
+    ] = Body(None, description=""),
 ) -> List[RunStateless]:
     """Search for stateless run.  This endpoint also functions as the endpoint to list all stateless Runs."""
-    run_search_request = _pre_process_RunSearchRequest(run_search_request)
     return Runs.search_for_runs(run_search_request)
 
 

--- a/src/agent_workflow_server/apis/threads_runs.py
+++ b/src/agent_workflow_server/apis/threads_runs.py
@@ -22,6 +22,7 @@ from fastapi import (  # noqa: F401
 from pydantic import Field, StrictBool, StrictInt, StrictStr
 from typing_extensions import Annotated
 
+from agent_workflow_server.agents.load import get_default_agent
 from agent_workflow_server.generated.models.extra_models import TokenModel  # noqa: F401
 from agent_workflow_server.generated.models.run import Run
 from agent_workflow_server.generated.models.run_create_stateful import RunCreateStateful
@@ -31,6 +32,15 @@ from agent_workflow_server.generated.models.run_wait_response_stateful import (
 )
 
 router = APIRouter()
+
+
+def _pre_process_RunCreateStateful(
+    run_create_stateful: RunCreateStateful,
+) -> RunCreateStateful:
+    """Pre-process the RunCreateStateful object to set the agent_id if not provided."""
+    if run_create_stateful.agent_id is None:
+        run_create_stateful.agent_id = get_default_agent().agent_id
+    return run_create_stateful
 
 
 @router.post(
@@ -88,6 +98,7 @@ async def create_and_stream_thread_run_output(
     run_create_stateful: RunCreateStateful = Body(None, description=""),
 ) -> RunOutputStream:
     """Create a run on a thread and join its output stream. See &#39;GET /runs/{run_id}/stream&#39; for details on the return values."""
+    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -110,6 +121,7 @@ async def create_and_wait_for_thread_run_output(
     run_create_stateful: RunCreateStateful = Body(None, description=""),
 ) -> RunWaitResponseStateful:
     """Create a run on a thread and block waiting for its output. See &#39;GET /runs/{run_id}/wait&#39; for details on the return values."""
+    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -132,6 +144,7 @@ async def create_thread_run(
     run_create_stateful: RunCreateStateful = Body(None, description=""),
 ) -> Run:
     """Create a run on a thread, return the run ID immediately. Don&#39;t wait for the final run output."""
+    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 

--- a/src/agent_workflow_server/apis/threads_runs.py
+++ b/src/agent_workflow_server/apis/threads_runs.py
@@ -34,11 +34,11 @@ from agent_workflow_server.generated.models.run_wait_response_stateful import (
 router = APIRouter()
 
 
-def _pre_process_RunCreateStateful(
+async def _validate_run_create_statefull(
     run_create_stateful: RunCreateStateful,
 ) -> RunCreateStateful:
-    """Pre-process the RunCreateStateful object to set the agent_id if not provided."""
     if run_create_stateful.agent_id is None:
+        """Pre-process the RunCreateStateless object to set the agent_id if not provided."""
         run_create_stateful.agent_id = get_default_agent().agent_id
     return run_create_stateful
 
@@ -95,10 +95,11 @@ async def create_and_stream_thread_run_output(
     thread_id: Annotated[StrictStr, Field(description="The ID of the thread.")] = Path(
         ..., description="The ID of the thread."
     ),
-    run_create_stateful: RunCreateStateful = Body(None, description=""),
+    run_create_stateful: Annotated[
+        RunCreateStateful, Depends(_validate_run_create_statefull)
+    ] = Body(None, description=""),
 ) -> RunOutputStream:
     """Create a run on a thread and join its output stream. See &#39;GET /runs/{run_id}/stream&#39; for details on the return values."""
-    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -118,10 +119,11 @@ async def create_and_wait_for_thread_run_output(
     thread_id: Annotated[StrictStr, Field(description="The ID of the thread.")] = Path(
         ..., description="The ID of the thread."
     ),
-    run_create_stateful: RunCreateStateful = Body(None, description=""),
+    run_create_stateful: Annotated[
+        RunCreateStateful, Depends(_validate_run_create_statefull)
+    ] = Body(None, description=""),
 ) -> RunWaitResponseStateful:
     """Create a run on a thread and block waiting for its output. See &#39;GET /runs/{run_id}/wait&#39; for details on the return values."""
-    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 
@@ -141,10 +143,11 @@ async def create_thread_run(
     thread_id: Annotated[StrictStr, Field(description="The ID of the thread.")] = Path(
         ..., description="The ID of the thread."
     ),
-    run_create_stateful: RunCreateStateful = Body(None, description=""),
+    run_create_stateful: Annotated[
+        RunCreateStateful, Depends(_validate_run_create_statefull)
+    ] = Body(None, description=""),
 ) -> Run:
     """Create a run on a thread, return the run ID immediately. Don&#39;t wait for the final run output."""
-    run_create_stateful = _pre_process_RunCreateStateful(run_create_stateful)
     raise HTTPException(status_code=500, detail="Not implemented")
 
 


### PR DESCRIPTION
# Description

Support of default agent-id for APIs that must support default agent-id from the spec.
The chosen default agent-id is the first one of the AGENTS list.

We check all struct which have "agent_id: Optional".
At this date, this impact:
RunCreateStateful
RunCreateStateless
RunCreate
RunSearchRequest

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
