### PR TITLE
fix: check if current running loop exists

### DIFF
--- a/src/agent_workflow_server/main.py
+++ b/src/agent_workflow_server/main.py
@@ -62,7 +62,12 @@ def start():
         load_agents()
         n_workers = int(os.environ.get("NUM_WORKERS", 5))
 
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         loop.create_task(start_workers(n_workers))
 
         config = uvicorn.Config(


### PR DESCRIPTION
# Description

Fixes issues like:

ERROR:    agent_workflow_server.main Exiting due to an unexpected error: There is no current event loop in thread 'MainThread'. 

Looks like this depends on how the "wrapped" agents runs (if in a new coroutine or not)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

