### PR TITLE
feat: support complex interrupts and validation

### DIFF
--- a/src/agent_workflow_server/services/message.py
+++ b/src/agent_workflow_server/services/message.py
@@ -7,7 +7,14 @@ type MessageType = Literal["control", "message", "interrupt"]
 
 
 class Message:
-    def __init__(self, type: MessageType, data: Any, event: Optional[str] = None):
+    def __init__(
+        self,
+        type: MessageType,
+        data: Any,
+        event: Optional[str] = None,
+        interrupt_name: Optional[str] = None,
+    ):
         self.type = type
         self.data = data
         self.event = event
+        self.interrupt_name = interrupt_name

--- a/src/agent_workflow_server/services/queue.py
+++ b/src/agent_workflow_server/services/queue.py
@@ -134,11 +134,17 @@ async def worker(worker_id: int):
                     "got message",
                     message_data=json.dumps(last_message.data),
                 )
-                validate_output(run_id, run["agent_id"], last_message.data)
+
+                # Validate only if not interrupt (implicticly validated by _insert_interrupt_name)
+                if last_message.type != "interrupt":
+                    validate_output(run_id, run["agent_id"], last_message.data)
+
                 DB.add_run_output(run_id, last_message.data)
                 if last_message.type == "interrupt":
                     interrupt = Interrupt(
-                        event=last_message.event, ai_data=last_message.data
+                        event=last_message.event,
+                        name=last_message.interrupt_name,
+                        ai_data=last_message.data,
                     )
                     DB.update_run(run_id, {"interrupt": interrupt})
                     await Runs.set_status(run_id, "interrupted")

--- a/src/agent_workflow_server/services/runs.py
+++ b/src/agent_workflow_server/services/runs.py
@@ -25,7 +25,7 @@ from agent_workflow_server.generated.models.value_run_result_update import (
     ValueRunResultUpdate,
 )
 from agent_workflow_server.services.threads import Threads
-from agent_workflow_server.storage.models import Run, RunInfo, RunStatus
+from agent_workflow_server.storage.models import Interrupt, Run, RunInfo, RunStatus
 from agent_workflow_server.storage.storage import DB
 
 from ..utils.tools import is_valid_uuid
@@ -283,6 +283,18 @@ class Runs:
                     values=msg_data,
                 )
             )
+
+    class Interrupts:
+        @staticmethod
+        def get_last(run_id: str) -> Optional[Interrupt]:
+            run = DB.get_run(run_id)
+            if run is None:
+                raise ValueError(f"Run {run_id} not found")
+            if run["status"] != "interrupted":
+                raise ValueError("Run is not in interrupted state")
+            if run.get("interrupt") is None:
+                raise ValueError(f"No interrupt found for run {run_id}")
+            return run["interrupt"]
 
     class Stream:
         @staticmethod

--- a/src/agent_workflow_server/services/runs.py
+++ b/src/agent_workflow_server/services/runs.py
@@ -25,6 +25,7 @@ from agent_workflow_server.generated.models.value_run_result_update import (
     ValueRunResultUpdate,
 )
 from agent_workflow_server.services.threads import Threads
+from agent_workflow_server.services.utils import check_run_is_interrupted
 from agent_workflow_server.storage.models import Interrupt, Run, RunInfo, RunStatus
 from agent_workflow_server.storage.storage import DB
 
@@ -182,12 +183,7 @@ class Runs:
     @staticmethod
     async def resume(run_id: str, user_input: Dict[str, Any]) -> ApiRun:
         run = DB.get_run(run_id)
-        if run is None:
-            raise ValueError("Run not found")
-        if run["status"] != "interrupted":
-            raise ValueError("Run is not in interrupted state")
-        if run.get("interrupt") is None:
-            raise ValueError(f"No interrupt found for run {run_id}")
+        check_run_is_interrupted(run)
 
         interrupt = run["interrupt"]
         interrupt["user_data"] = user_input
@@ -286,14 +282,9 @@ class Runs:
 
     class Interrupts:
         @staticmethod
-        def get_last(run_id: str) -> Optional[Interrupt]:
+        def get_last(run_id: str) -> Interrupt:
             run = DB.get_run(run_id)
-            if run is None:
-                raise ValueError(f"Run {run_id} not found")
-            if run["status"] != "interrupted":
-                raise ValueError("Run is not in interrupted state")
-            if run.get("interrupt") is None:
-                raise ValueError(f"No interrupt found for run {run_id}")
+            check_run_is_interrupted(run)
             return run["interrupt"]
 
     class Stream:

--- a/src/agent_workflow_server/services/stream.py
+++ b/src/agent_workflow_server/services/stream.py
@@ -1,16 +1,50 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import AsyncGenerator
+from typing import AsyncGenerator, List
+
+import jsonschema
 
 from agent_workflow_server.agents.load import get_agent_info
+from agent_workflow_server.generated.models.agent_acp_spec_interrupts_inner import (
+    AgentACPSpecInterruptsInner,
+)
 from agent_workflow_server.storage.models import Run
 
 from .runs import Message
+
+
+def _insert_interrupt_name(
+    interrupts: List[AgentACPSpecInterruptsInner], interrupt_message: Message
+):
+    """
+    Iterates over the 'interrupt' schema in the ACP Descriptor to find the interrupt name, and inserts it into the Message.
+    """
+    for interrupt in interrupts:
+        # Return the first interrupt_type that validates the json schema
+        try:
+            jsonschema.validate(
+                instance=interrupt_message.data, schema=interrupt.interrupt_payload
+            )
+            interrupt_message.interrupt_name = interrupt.interrupt_type
+            break
+        except jsonschema.ValidationError:
+            # If the validation fails, continue and try the next one
+            continue
+    else:
+        raise ValueError(
+            f"Interrupt schemas mismatch: could not find matching interrupt type for the received interrupt payload: {interrupt_message.data}. Check the interrupts schemas in the ACP Descriptor."
+        )
+
+    return interrupt_message
 
 
 async def stream_run(run: Run) -> AsyncGenerator[Message, None]:
     agent_info = get_agent_info(run["agent_id"])
     agent = agent_info.agent
     async for message in agent.astream(run=run):
+        if message.type == "interrupt":
+            message = _insert_interrupt_name(
+                agent_info.manifest.specs.interrupts, message
+            )
         yield message

--- a/src/agent_workflow_server/services/utils.py
+++ b/src/agent_workflow_server/services/utils.py
@@ -1,0 +1,13 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from agent_workflow_server.storage.models import Run
+
+
+def check_run_is_interrupted(run: Run):
+    if run is None:
+        raise ValueError("Run not found")
+    if run["status"] != "interrupted":
+        raise ValueError("Run is not in interrupted state")
+    if run.get("interrupt") is None:
+        raise ValueError(f"No interrupt found for run {run['run_id']}")

--- a/src/agent_workflow_server/services/validation.py
+++ b/src/agent_workflow_server/services/validation.py
@@ -16,6 +16,7 @@ from agent_workflow_server.generated.models.run_create_stateful import (
 from agent_workflow_server.generated.models.run_create_stateless import (
     RunCreateStateless,
 )
+from agent_workflow_server.services.utils import check_run_is_interrupted
 from agent_workflow_server.storage.storage import DB
 
 logger = logging.getLogger(__name__)
@@ -85,12 +86,7 @@ def validate_run_create(
 
 def validate_resume_run(run_id: str, body: Dict[str, Any]):
     run = DB.get_run(run_id)
-    if run is None:
-        raise ValueError("Run not found")
-    if run["status"] != "interrupted":
-        raise ValueError("Run is not in interrupted state")
-    if run.get("interrupt") is None:
-        raise ValueError(f"No interrupt found for run {run_id}")
+    check_run_is_interrupted(run)
 
     interrupt_name = run["interrupt"]["name"]
     interrupts_schemas: List[AgentACPSpecInterruptsInner] = get_agent_schemas(

--- a/src/agent_workflow_server/services/validation.py
+++ b/src/agent_workflow_server/services/validation.py
@@ -2,17 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any
+from typing import Any, Dict, List
 
 import jsonschema
 
 from agent_workflow_server.agents.load import AGENTS
+from agent_workflow_server.generated.models.agent_acp_spec_interrupts_inner import (
+    AgentACPSpecInterruptsInner,
+)
 from agent_workflow_server.generated.models.run_create_stateful import (
     RunCreateStateful,
 )
 from agent_workflow_server.generated.models.run_create_stateless import (
     RunCreateStateless,
 )
+from agent_workflow_server.storage.storage import DB
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +45,12 @@ def get_agent_schemas(agent_id: str):
         raise ValueError(f"Agent {agent_id} not found")
 
     specs = agent_info.manifest.specs
-    return {"input": specs.input, "output": specs.output, "config": specs.config}
+    return {
+        "input": specs.input,
+        "output": specs.output,
+        "config": specs.config,
+        "interrupts": specs.interrupts,
+    }
 
 
 def validate_output(run_id, agent_id: str, output: Any) -> None:
@@ -72,3 +81,29 @@ def validate_run_create(
         validate_against_schema(run_create.config.configurable, schemas["config"])
 
     return run_create
+
+
+def validate_resume_run(run_id: str, body: Dict[str, Any]):
+    run = DB.get_run(run_id)
+    if run is None:
+        raise ValueError("Run not found")
+    if run["status"] != "interrupted":
+        raise ValueError("Run is not in interrupted state")
+    if run.get("interrupt") is None:
+        raise ValueError(f"No interrupt found for run {run_id}")
+
+    interrupt_name = run["interrupt"]["name"]
+    interrupts_schemas: List[AgentACPSpecInterruptsInner] = get_agent_schemas(
+        run["agent_id"]
+    )["interrupts"]
+
+    # Get interrupt_schema given the interrupt_name
+    for interrupt_schema in interrupts_schemas:
+        if interrupt_schema.interrupt_type == interrupt_name:
+            break
+    else:
+        raise ValueError(f"Interrupt {interrupt_name} not found")
+
+    validate_against_schema(
+        body, interrupt_schema.resume_payload, "Resume payload not valid"
+    )

--- a/src/agent_workflow_server/storage/models.py
+++ b/src/agent_workflow_server/storage/models.py
@@ -11,6 +11,7 @@ class Interrupt(TypedDict):
     """Definition for an Interrupt message"""
 
     event: str
+    name: str
     ai_data: Any
     user_data: Optional[Any]
 

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -17,7 +17,7 @@ MOCK_RUN_OUTPUT = {"message": "The color of the sky is blue"}
 
 MOCK_RUN_INPUT_INTERRUPT = {"message": "Please interrupt"}
 MOCK_RUN_EVENT_INTERRUPT = "__mock_interrupt__"
-MOCK_RUN_OUTPUT_INTERRUPT = {"message": "How can I help you?"}
+MOCK_RUN_OUTPUT_INTERRUPT = {"interrupt_message": "How can I help you?"}
 
 MOCK_THREAD_ID = "3f1e2549-5799-4321-91ae-2a4881d55526"
 

--- a/tests/mock_manifest.json
+++ b/tests/mock_manifest.json
@@ -37,7 +37,41 @@
             "interrupts": false,
             "callbacks": false
         },
-        "interrupts": []
+        "interrupts": [
+            {
+                "interrupt_type": "mock_interrupt",
+                "interrupt_payload": {
+                    "type": "object",
+                    "title": "Mock interrupt",
+                    "description": "A Mock interrupt",
+                    "properties": {
+                        "interrupt_message": {
+                            "title": "Question",
+                            "description": "Natural language question that is going to be asked by this agent",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "interrupt_message"
+                    ]
+                },
+                "resume_payload": {
+                    "type": "object",
+                    "title": "Mock interrupt answer",
+                    "description": "Answer to the mock interrupt",
+                    "properties": {
+                        "message": {
+                            "title": "Answer",
+                            "description": "Natural language answer to the question asked by this agent",
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "message"
+                    ]
+                }
+            }
+        ]
     },
     "dependencies": [],
     "deployment": {


### PR DESCRIPTION
# Description

Adds support to use custom interrupts (defined in ACP descriptor https://github.com/agntcy/acp-spec/blob/main/openapi.json#L2097)

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
