### PR TITLE
fix: none webhook

### DIFF
--- a/src/agent_workflow_server/services/runs.py
+++ b/src/agent_workflow_server/services/runs.py
@@ -105,7 +105,7 @@ async def _call_webhook(run: Run) -> None:
     Args:
         run (Run): The Run to send to the webhook.
     """
-    if not run["webhook"]:
+    if not run.get("webhook"):
         return
 
     try:


### PR DESCRIPTION
Fixes errors like:


  File "agent_workflow_server/services/runs.py", line 108, in _call_webhook
    if not run["webhook"]:
           ~~~^^^^^^^^^^^