### PR TITLE
feat: add support for streaming interrupts and errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,8 @@ run:
 	poetry run server
 
 test:
+	poetry install
+	if [ -n "${AGWS_STORAGE_PATH}" ]; then rm "${AGWS_STORAGE_PATH}" ; elif [ -r "agws_storage.pkl" ]; then rm "agws_storage.pkl" ; fi
 	poetry run pytest
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ run:
 
 test:
 	poetry install
-	if [ -n "${AGWS_STORAGE_PATH}" ]; then rm "${AGWS_STORAGE_PATH}" ; elif [ -r "agws_storage.pkl" ]; then rm "agws_storage.pkl" ; fi
-	poetry run pytest
+	AGWS_STORAGE_PERSIST=False poetry run pytest
 
 format:
 	poetry run ruff format .

--- a/src/agent_workflow_server/services/queue.py
+++ b/src/agent_workflow_server/services/queue.py
@@ -162,7 +162,7 @@ async def worker(worker_id: int):
 
             DB.update_run_info(run_id, run_info)
             await Runs.set_status(run_id, "error")
-            log_run(worker_id, run_id, "exeeded attempts")
+            log_run(worker_id, run_id, "exceeded attempts")
 
         except Exception as error:
             ended_at = datetime.now().timestamp()
@@ -184,10 +184,7 @@ async def worker(worker_id: int):
                 **{"error": error, **run_stats(run_info)},
             )
 
-            # FIXME: ACP spec does not currently include error messages
-            # in streams
-            await Runs.Stream.publish(run_id, Message(type="message", data={}))
-
+            await Runs.Stream.publish(run_id, Message(type="message", data=str(error)))
             await RUNS_QUEUE.put(run_id)  # Re-queue for retry
 
         finally:

--- a/src/agent_workflow_server/services/runs.py
+++ b/src/agent_workflow_server/services/runs.py
@@ -332,7 +332,7 @@ class Runs:
                         values=msg_data,
                     )
                 )
-            else:
+            elif run_status == "error":
                 yield StreamEventPayload(
                     ValueRunErrorUpdate(
                         type="error",
@@ -343,6 +343,8 @@ class Runs:
                         errcode=0,
                     )
                 )
+            else:
+                raise ValueError(f"Run status {run_status} unknown")
 
     class Interrupts:
         @staticmethod

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -289,8 +289,7 @@ async def test_search_runs(
         (
             ApiRunCreate(agent_id=MOCK_AGENT_ID, input=MOCK_RUN_INPUT_ERROR),
             "error",
-            # FIXME: ACP spec does not currently include error messages in streams
-            {},
+            MOCK_RUN_OUTPUT_ERROR,
         ),
         (
             ApiRunCreate(agent_id=MOCK_AGENT_ID, input=MOCK_RUN_INPUT_STREAM),
@@ -341,6 +340,19 @@ async def test_invoke_stream(
 
                     assert event.actual_instance.run_id == new_run.run_id
                     assert output == expected_json
+                    assert event.actual_instance.status == expected_status
+                elif event.actual_instance.type == "interrupt":
+                    output = json.dumps(event.actual_instance.interrupt, sort_keys=True)
+                    expected_json = json.dumps(exp_output, sort_keys=True)
+
+                    assert event.actual_instance.run_id == new_run.run_id
+                    assert output == expected_json
+                    assert event.actual_instance.status == expected_status
+                elif event.actual_instance.type == "error":
+                    output = event.actual_instance.description
+
+                    assert event.actual_instance.run_id == new_run.run_id
+                    assert output == exp_output
                     assert event.actual_instance.status == expected_status
                 else:
                     assert False, (


### PR DESCRIPTION
# Description

Add support for streaming event types for interrupts and errors. These were added in ACP spec version 0.2.2.

## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
