### PR TITLE
fix: update OASF extension schema name

### DIFF
--- a/tests/agents/jokeflow_manifest.json
+++ b/tests/agents/jokeflow_manifest.json
@@ -11,7 +11,7 @@
   "skills": [],
   "locators": [],
   "extensions": [{
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "data": {
         "acp": {
           "capabilities": {

--- a/tests/agents/jokereviewer_manifest.json
+++ b/tests/agents/jokereviewer_manifest.json
@@ -11,7 +11,7 @@
   "skills": [],
   "locators": [],
   "extensions": [{
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "data": {
         "acp": {
           "input": {

--- a/tests/agents/mailcomposer.json
+++ b/tests/agents/mailcomposer.json
@@ -11,7 +11,7 @@
   "skills": [],
   "locators": [],
   "extensions": [{
-      "name": "oasf.agntcy.org/feature/runtime/manifest",
+      "name": "schema.oasf.agntcy.org/features/runtime/manifest",
       "data": {
         "acp": {
           "capabilities": {

--- a/tests/mock_manifest.json
+++ b/tests/mock_manifest.json
@@ -4,7 +4,7 @@
     ],
     "extensions": [
         {
-            "name": "oasf.agntcy.org/feature/runtime/manifest",
+            "name": "schema.oasf.agntcy.org/features/runtime/manifest",
             "data": {
                 "deployment": {
                     "agent_deps": [],


### PR DESCRIPTION
# Description

This PR updates the OASF extension name to match the specification: "schema.oasf.agntcy.org/features/runtime/manifest"

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/workflow-srv/blob/main/docs/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
